### PR TITLE
package.json update for npm v5

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "typings": "index.ts",
   "scripts": {
     "tsc": "tsc",
-    "prepublish": "rm -rf built && tsc"
+    "prepare": "rm -rf built && tsc"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Use new prepare npm event introduced in npm 4 as prepublish is no longer called on 'npm install' in npm 5.