### PR TITLE
Fix typescript error

### DIFF
--- a/image-zoom/image-zoom.component.tsx
+++ b/image-zoom/image-zoom.component.tsx
@@ -54,7 +54,7 @@ export default class ImageViewer extends React.Component<typings.PropsDefine, ty
     private centerDiffY = 0
 
     // 计算长按的 timeout
-    private longPressTimeout: number
+    private longPressTimeout: any
 
     // 上一次点击的时间
     private lastClickTime = 0


### PR DESCRIPTION
With the current code there is the following error:

node_modules/react-native-image-pan-zoom/image-zoom/image-zoom.component.tsx(99,17): error TS2322: Type 'Timer' is not assignable to type 'number'.

It looks like because this code is used in both a nodejs and web context in the web setTimeout returns a number but in node.js it returns a NodeJS.Timer. Changing this type to any removes this error. Maybe there is a better way.