### PR TITLE
Add methods that report move events and layout events

### DIFF
--- a/image-zoom/image-zoom.component.tsx
+++ b/image-zoom/image-zoom.component.tsx
@@ -325,6 +325,16 @@ export default class ImageViewer extends React.Component<typings.PropsDefine, ty
                         this.zoomLastDistance = this.zoomCurrentDistance
                     }
                 }
+
+                if(this.props.onMove) {
+                  this.props.onMove({
+                    type: 'onPanResponderMove',
+                    positionX: this.positionX,
+                    positionY: this.positionY,
+                    scale: this.scale,
+                    zoomCurrentDistance: this.zoomCurrentDistance,
+                  })
+                }
             },
             onPanResponderRelease: (evt, gestureState) => {
                 // 双击缩放了，结束手势就不需要操作了
@@ -412,6 +422,16 @@ export default class ImageViewer extends React.Component<typings.PropsDefine, ty
                 } else {
                     this.props.responderRelease(gestureState.vx, this.scale)
                 }
+
+                if(this.props.onMove) {
+                  this.props.onMove({
+                    type: 'onPanResponderRelease',
+                    positionX: this.positionX,
+                    positionY: this.positionY,
+                    scale: this.scale,
+                    zoomCurrentDistance: this.zoomCurrentDistance,
+                  })
+                }
             },
             onPanResponderTerminate: (_evt, _gestureState) => {
 
@@ -425,6 +445,9 @@ export default class ImageViewer extends React.Component<typings.PropsDefine, ty
     handleLayout(_event: LayoutChangeEvent) {
         //this.centerX = event.nativeEvent.layout.x + event.nativeEvent.layout.width / 2
         //this.centerY = event.nativeEvent.layout.y + event.nativeEvent.layout.height / 2
+        if(this.props.layoutChange) {
+            this.props.layoutChange(_event);
+        }
     }
 
     /**

--- a/image-zoom/image-zoom.type.ts
+++ b/image-zoom/image-zoom.type.ts
@@ -83,6 +83,16 @@ export interface PropsDefine extends ReactNative.ViewProperties {
     onDoubleClick?: ()=>void
 
     /**
+     * If provided, this will be called everytime the map is moved
+     */
+    onMove?: (position?: object)=>void
+
+    /**
+     * If provided, this method will be called when the onLayout event fires
+     */
+    layoutChange?: (event?: object)=>void
+
+    /**
      * 双击时的间隔
      */
     doubleClickInterval?: number
@@ -139,4 +149,3 @@ export class State implements StateDefine {
     centerX = 0.5
     centerY = 0.5
 }
-

--- a/readme.md
+++ b/readme.md
@@ -81,3 +81,4 @@ AppRegistry.registerComponent('myproject', () => ImageZoom);
 | longPressTime | number | long press threshold | 800 |
 | onLongPress | ()=>void | on longPress | ()=> {} |
 | doubleClickInterval | number | time allocated for second click to be considered as doublClick event | 175 |
+| onMove | (object)=>void | reports movement position data (helpful to build overlays) | ()=> {} |  


### PR DESCRIPTION
This PR adds a couple of methods that can callback with information about movements to the parent component.

This is useful if you want to do something like build an overlay on the image. You can tell where the image is zoomed in to and what the scale is. 

Let me know if there are any concerns, I have tested this and am using it on my fork. 