### PR TITLE
Add centerOn parameter that causes image to pan and zoom via props

### DIFF
--- a/image-zoom/image-zoom.type.ts
+++ b/image-zoom/image-zoom.type.ts
@@ -93,6 +93,12 @@ export interface PropsDefine extends ReactNative.ViewProperties {
     layoutChange?: (event?: object) => void
 
     /**
+    * If provided this will cause the view to zoom and pan to the center point
+    * Duration is optional and defaults to 300 ms.
+    */
+    centerOn?: { x: number, y: number, scale: number, duration: number }
+
+    /**
      * 双击时的间隔
      */
     doubleClickInterval?: number
@@ -132,6 +138,7 @@ export class Props extends PropsGaea implements PropsDefine {
     onDoubleClick = () => {
     }
     doubleClickInterval = 175
+    centerOn = undefined
 }
 
 export interface StateDefine {

--- a/readme.md
+++ b/readme.md
@@ -82,3 +82,4 @@ AppRegistry.registerComponent('myproject', () => ImageZoom);
 | onLongPress | ()=>void | on longPress | ()=> {} |
 | doubleClickInterval | number | time allocated for second click to be considered as doublClick event | 175 |
 | onMove | (object)=>void | reports movement position data (helpful to build overlays) | ()=> {} |  
+| centerOn | { x: number, y: number, scale: number, duration: number } | if given this will cause the map to pan and zoom to the desired location | undefined


### PR DESCRIPTION
I have continued to use the module on a project that overlaying elements on top of a zoommable image. Another feature I needed on this project was the ability to programmatically zoom and pan in response to click event on an overlay. 

This PR adds the ability to pass a prop called ```centerOn``` which will pan + zoom the image to a desired location without user interaction. 

This feature is only activated if the prop ```centerOn``` is used.  I also refactored the ```imageDidMove``` to remove duplicated code. 