### PR TITLE
decrease the sensitivity to enter horizontal swiping mode.

### DIFF
--- a/src/image-zoom/image-zoom.component.tsx
+++ b/src/image-zoom/image-zoom.component.tsx
@@ -220,7 +220,7 @@ export default class ImageViewer extends React.Component<Props, State> {
           if (this.props.panToMove) {
             // 处理左右滑，如果正在 swipeDown，左右滑失效
             if (this.swipeDownOffset === 0) {
-              if (diffX !== 0) {
+              if (Math.abs(diffX) > Math.abs(diffY)) {
                 this.isHorizontalWrap = true;
               }
 


### PR DESCRIPTION
Hi,
我稍微修改了一下進入左右滑模式的判斷方式.
原本的版本非常容易被判定為左右滑, 很難被判定為下滑
這導致swipeDown非常不靈敏
希望這樣的改動會有幫助

Thanks
