### PR TITLE
Supports parent stylesheets

### DIFF
--- a/src/image-zoom/image-zoom.component.tsx
+++ b/src/image-zoom/image-zoom.component.tsx
@@ -6,7 +6,8 @@ import {
   PanResponderInstance,
   Platform,
   PlatformOSType,
-  View
+  View,
+  StyleSheet
 } from 'react-native';
 import styles from './image-zoom.style';
 import { ICenterOn, Props, State } from './image-zoom.type';
@@ -663,11 +664,13 @@ export default class ImageViewer extends React.Component<Props, State> {
       ]
     };
 
+    const parentStyles = StyleSheet.flatten(this.props.style);
+
     return (
       <View
         style={{
           ...styles.container,
-          ...this.props.style,
+          ...parentStyles,
           width: this.props.cropWidth,
           height: this.props.cropHeight
         }}


### PR DESCRIPTION
[StyleSheet Flatten](https://facebook.github.io/react-native/docs/stylesheet.html) allows users to pass in whatever style object they want (either from StyleSheet.create() or inline styles) while still correctly applying the styles. 