### PR TITLE
Accept responder props

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 built
+.vscode

--- a/readme.md
+++ b/readme.md
@@ -53,37 +53,40 @@ export default class App extends React.Component {
 
 ### Document
 
-| Props                      | Type                                                                                                                             | Description                                                                                                                                                           | DefaultValue |
-| -------------------------- | -------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------ |
-| **cropWidth(required)**    | number                                                                                                                           | operating area width                                                                                                                                                  | 100          |
-| **cropHeight(required)**   | number                                                                                                                           | operating area height                                                                                                                                                 | 100          |
-| **imageWidth(required)**   | number                                                                                                                           | picture width                                                                                                                                                         | 100          |
-| **imageHeight(required)**  | number                                                                                                                           | picture height                                                                                                                                                        | 100          |
-| onClick                    | (eventParams: [IOnClick](https://github.com/ascoders/react-native-image-zoom/blob/master/src/image-zoom/image-zoom.type.ts))=>void                                                                                                                         | onClick                                                                                                                                                               | ()=>{}       |
-| panToMove                  | boolean                                                                                                                          | allow to move picture with one finger                                                                                                                                 | true         |
-| pinchToZoom                | boolean                                                                                                                          | allow scale with two fingers                                                                                                                                          | true         |
-| clickDistance              | number                                                                                                                           | how many finger movement can also trigger `onClick`                                                                                                                   | 10           |
-| horizontalOuterRangeOffset | (offsetX?: number)=>void                                                                                                         | horizontal beyond the distance, the parent to do picture switching, you can listen to this function. When this function is triggered, you can do the switch operation | ()=>{}       |
-| onDragLeft                 | ()=>void                                                                                                                         | trigger to switch to the left of the graph, the left sliding speed exceeds the threshold when triggered                                                               | ()=>{}       |
-| responderRelease           | (vx: number)=>void                                                                                                               | let go but do not cancel                                                                                                                                              | ()=>{}       |
-| maxOverflow                | number                                                                                                                           | maximum sliding threshold                                                                                                                                             | 100          |
-| longPressTime              | number                                                                                                                           | long press threshold                                                                                                                                                  | 800          |
-| onLongPress                | ()=>void                                                                                                                         | on longPress                                                                                                                                                          | ()=> {}      |
-| doubleClickInterval        | number                                                                                                                           | time allocated for second click to be considered as doublClick event                                                                                                  | 175          |
-| onMove                     | ( position: [IOnMove](https://github.com/ascoders/react-native-image-zoom/blob/master/src/image-zoom/image-zoom.type.ts) )=>void | reports movement position data (helpful to build overlays)                                                                                                            | ()=> {}      |
-| centerOn                   | { x: number, y: number, scale: number, duration: number }                                                                        | if given this will cause the map to pan and zoom to the desired location                                                                                              | undefined    |
-| enableSwipeDown            | boolean                                                                                                                          | for enabling vertical movement if user doesn't want it                                                                                                                | false        |  | false |
-| enableCenterFocus          | boolean                                                                                                                          | for disabling focus on image center if user doesn't want it                                                                                                           | true         |
-| onSwipeDown                | () => void                                                                                                                       | function that fires when user swipes down                                                                                                                             | null         |
-| swipeDownThreshold         | number                                                                                                                           | threshold for firing swipe down function                                                                                                                              | 230          |
-| minScale                   | number                                                                                                                           | minimum zoom scale                                                                                                                                                    | 0.6          |
-| maxScale                   | number                                                                                                                           | maximum zoom scale                                                                                                                                                    | 10           |
+| Props | Type | Description | DefaultValue |
+| --- | --- | --- | --- |
+| **cropWidth(required)** | number | operating area width | 100 |
+| **cropHeight(required)** | number | operating area height | 100 |
+| **imageWidth(required)** | number | picture width | 100 |
+| **imageHeight(required)** | number | picture height | 100 |
+| onClick | (eventParams: [IOnClick](https://github.com/ascoders/react-native-image-zoom/blob/master/src/image-zoom/image-zoom.type.ts))=>void | onClick | ()=>{} |
+| panToMove | boolean | allow to move picture with one finger | true |
+| pinchToZoom | boolean | allow scale with two fingers | true |
+| clickDistance | number | how many finger movement can also trigger `onClick` | 10 |
+| horizontalOuterRangeOffset | (offsetX?: number)=>void | horizontal beyond the distance, the parent to do picture switching, you can listen to this function. When this function is triggered, you can do the switch operation | ()=>{} |
+| onDragLeft | ()=>void | trigger to switch to the left of the graph, the left sliding speed exceeds the threshold when triggered | ()=>{} |
+| responderRelease | (vx: number)=>void | let go but do not cancel | ()=>{} |
+| maxOverflow | number | maximum sliding threshold | 100 |
+| longPressTime | number | long press threshold | 800 |
+| onLongPress | ()=>void | on longPress | ()=> {} |
+| doubleClickInterval | number | time allocated for second click to be considered as doublClick event | 175 |
+| onMove | ( position: [IOnMove](https://github.com/ascoders/react-native-image-zoom/blob/master/src/image-zoom/image-zoom.type.ts) )=>void | reports movement position data (helpful to build overlays) | ()=> {} |
+| centerOn | { x: number, y: number, scale: number, duration: number } | if given this will cause the map to pan and zoom to the desired location | undefined |
+| enableSwipeDown | boolean | for enabling vertical movement if user doesn't want it | false |  | false |
+| enableCenterFocus | boolean | for disabling focus on image center if user doesn't want it | true |
+| onSwipeDown | () => void | function that fires when user swipes down | null |
+| swipeDownThreshold | number | threshold for firing swipe down function | 230 |
+| minScale | number | minimum zoom scale | 0.6 |
+| maxScale | number | maximum zoom scale | 10 |
+| onStartShouldSetPanResponder | () => boolean | Override onStartShouldSetPanResponder behavior | () => true |
+| onMoveShouldSetPanResponder | () => boolean | Override onMoveShouldSetPanResponder behavior | undefined |
+| onPanResponderTerminationRequest | () => boolean | Override onMoveShouldSetPanResponder behavior | () => false |
 
-| Method     | params    | Description                                                                                                      |
-| ---------- | --------- | ---------------------------------------------------------------------------------------------------------------- |
-| reset      |           | Reset the position and the scale of the image                                                                    |
-| resetScale |           | Reset the scale of the image                                                                                     |
-| centerOn   | ICenterOn | Centers the image in the position indicated. ICenterOn={ x: number, y: number, scale: number, duration: number } |
+| Method | params | Description |
+| --- | --- | --- |
+| reset |  | Reset the position and the scale of the image |
+| resetScale |  | Reset the scale of the image |
+| centerOn | ICenterOn | Centers the image in the position indicated. ICenterOn={ x: number, y: number, scale: number, duration: number } |
 
 ## Development pattern
 

--- a/src/image-zoom/image-zoom.component.tsx
+++ b/src/image-zoom/image-zoom.component.tsx
@@ -1,11 +1,11 @@
 import * as React from 'react';
 import { Animated, LayoutChangeEvent, PanResponder, PanResponderInstance, StyleSheet, View } from 'react-native';
 import styles from './image-zoom.style';
-import { ICenterOn, Props, State } from './image-zoom.type';
+import { ICenterOn, ImageZoomProps, ImageZoomState } from './image-zoom.type';
 
-export default class ImageViewer extends React.Component<Props, State> {
-  public static defaultProps = new Props();
-  public state = new State();
+export default class ImageViewer extends React.Component<ImageZoomProps, ImageZoomState> {
+  public static defaultProps = new ImageZoomProps();
+  public state = new ImageZoomState();
 
   // 上次/当前/动画 x 位移
   private lastPositionX: number | null = null;
@@ -557,7 +557,7 @@ export default class ImageViewer extends React.Component<Props, State> {
     }
   }
 
-  public componentWillReceiveProps(nextProps: Props) {
+  public componentWillReceiveProps(nextProps: ImageZoomProps) {
     // Either centerOn has never been called, or it is a repeat and we should ignore it
     if (
       (nextProps.centerOn && !this.props.centerOn) ||

--- a/src/image-zoom/image-zoom.component.tsx
+++ b/src/image-zoom/image-zoom.component.tsx
@@ -1,14 +1,5 @@
 import * as React from 'react';
-import {
-  Animated,
-  LayoutChangeEvent,
-  PanResponder,
-  PanResponderInstance,
-  Platform,
-  PlatformOSType,
-  StyleSheet,
-  View
-} from 'react-native';
+import { Animated, LayoutChangeEvent, PanResponder, PanResponderInstance, StyleSheet, View } from 'react-native';
 import styles from './image-zoom.style';
 import { ICenterOn, Props, State } from './image-zoom.type';
 
@@ -77,8 +68,8 @@ export default class ImageViewer extends React.Component<Props, State> {
   public componentWillMount() {
     this.imagePanResponder = PanResponder.create({
       // 要求成为响应者：
-      onStartShouldSetPanResponder: () => true,
-      onPanResponderTerminationRequest: () => false,
+      onStartShouldSetPanResponder: this.props.onStartShouldSetResponder,
+      onPanResponderTerminationRequest: this.props.onPanResponderTerminationRequest,
 
       onPanResponderGrant: evt => {
         // 开始手势操作

--- a/src/image-zoom/image-zoom.component.tsx
+++ b/src/image-zoom/image-zoom.component.tsx
@@ -68,7 +68,8 @@ export default class ImageViewer extends React.Component<Props, State> {
   public componentWillMount() {
     this.imagePanResponder = PanResponder.create({
       // 要求成为响应者：
-      onStartShouldSetPanResponder: this.props.onStartShouldSetResponder,
+      onStartShouldSetPanResponder: this.props.onStartShouldSetPanResponder,
+      onMoveShouldSetPanResponder: this.props.onMoveShouldSetPanResponder,
       onPanResponderTerminationRequest: this.props.onPanResponderTerminationRequest,
 
       onPanResponderGrant: evt => {

--- a/src/image-zoom/image-zoom.type.ts
+++ b/src/image-zoom/image-zoom.type.ts
@@ -1,4 +1,4 @@
-import { ViewStyle } from 'react-native';
+import { GestureResponderEvent, PanResponderGestureState, ViewStyle } from 'react-native';
 
 export interface ICenterOn {
   x: number;
@@ -114,7 +114,7 @@ export class Props {
   /**
    * Allows defining the onMoveShouldSetResponder behavior.
    */
-  public onMoveShouldSetPanResponder?: () => boolean;
+  public onMoveShouldSetPanResponder?: (event: GestureResponderEvent, gestureState: PanResponderGestureState) => boolean;
 
   /**
    * 单击的回调
@@ -184,13 +184,13 @@ export class Props {
    * Allows overriding the default onStartShouldSetPanResponder behavior.
    * By default, always becomes the responder
    */
-  public onStartShouldSetPanResponder?: () => boolean = () => true;
+  public onStartShouldSetPanResponder?: (event: GestureResponderEvent, gestureState: PanResponderGestureState) => boolean = () => true;
 
   /**
    * Allows overriding the default onPanResponderTerminationRequest behavior.
    * By default, doesn't terminate until the press ends
    */
-  public onPanResponderTerminationRequest?: () => boolean = () => false;
+  public onPanResponderTerminationRequest?: (event: GestureResponderEvent, gestureState: PanResponderGestureState) => boolean = () => false;
 }
 
 export class State {

--- a/src/image-zoom/image-zoom.type.ts
+++ b/src/image-zoom/image-zoom.type.ts
@@ -7,7 +7,7 @@ export interface ICenterOn {
   duration: number;
 }
 
-interface IOnMove {
+export interface IOnMove {
   type: string;
   positionX: number;
   positionY: number;
@@ -22,7 +22,7 @@ export interface IOnClick {
   pageY: number;
 }
 
-export class Props {
+export class ImageZoomProps {
   /**
    * 操作区域宽度
    */
@@ -193,7 +193,7 @@ export class Props {
   public onPanResponderTerminationRequest?: (event: GestureResponderEvent, gestureState: PanResponderGestureState) => boolean = () => false;
 }
 
-export class State {
+export class ImageZoomState {
   /**
    * 中心 x 坐标
    */

--- a/src/image-zoom/image-zoom.type.ts
+++ b/src/image-zoom/image-zoom.type.ts
@@ -16,10 +16,10 @@ interface IOnMove {
 }
 
 export interface IOnClick {
-  locationX: number,
-  locationY: number,
-  pageX: number,
-  pageY: number
+  locationX: number;
+  locationY: number;
+  pageX: number;
+  pageY: number;
 }
 
 export class Props {
@@ -174,6 +174,18 @@ export class Props {
   public onSwipeDown?: () => void = () => {
     //
   };
+
+  /**
+   * Allows overriding the default onStartShouldSetResponder behavior.
+   * By default, always becomes the responder
+   */
+  public onStartShouldSetResponder = () => true;
+
+  /**
+   * Allows overriding the default onPanResponderTerminationRequest behavior.
+   * By default, doesn't terminate until the press ends
+   */
+  public onPanResponderTerminationRequest = () => false;
 }
 
 export class State {

--- a/src/image-zoom/image-zoom.type.ts
+++ b/src/image-zoom/image-zoom.type.ts
@@ -141,7 +141,7 @@ export class Props {
    * 横向超出的距离，父级做图片切换时，可以监听这个函数
    * 当此函数触发时，可以做切换操作
    */
-  public horizontalOuterRangeOffset?: (offsetX?: number) => void = () => {
+  public horizontalOuterRangeOffset?: (offsetX: number) => void = () => {
     //
   };
 
@@ -155,21 +155,21 @@ export class Props {
   /**
    * 松手但是没有取消看图的回调
    */
-  public responderRelease?: (vx?: number, scale?: number) => void = () => {
+  public responderRelease?: (vx: number, scale: number) => void = () => {
     //
   };
 
   /**
    * If provided, this will be called everytime the map is moved
    */
-  public onMove?: (position?: IOnMove) => void = () => {
+  public onMove?: (position: IOnMove) => void = () => {
     //
   };
 
   /**
    * If provided, this method will be called when the onLayout event fires
    */
-  public layoutChange?: (event?: object) => void = () => {
+  public layoutChange?: (event: object) => void = () => {
     //
   };
 

--- a/src/image-zoom/image-zoom.type.ts
+++ b/src/image-zoom/image-zoom.type.ts
@@ -112,6 +112,11 @@ export class Props {
   public maxScale?: number = 10;
 
   /**
+   * Allows defining the onMoveShouldSetResponder behavior.
+   */
+  public onMoveShouldSetPanResponder?: () => boolean;
+
+  /**
    * 单击的回调
    */
   public onClick?: (eventParams: IOnClick) => void = () => {
@@ -179,18 +184,13 @@ export class Props {
    * Allows overriding the default onStartShouldSetPanResponder behavior.
    * By default, always becomes the responder
    */
-  public onStartShouldSetPanResponder = () => true;
-
-  /**
-   * Allows defining the onMoveShouldSetResponder behavior.
-   */
-  public onMoveShouldSetPanResponder?: () => boolean;
+  public onStartShouldSetPanResponder?: () => boolean = () => true;
 
   /**
    * Allows overriding the default onPanResponderTerminationRequest behavior.
    * By default, doesn't terminate until the press ends
    */
-  public onPanResponderTerminationRequest = () => false;
+  public onPanResponderTerminationRequest?: () => boolean = () => false;
 }
 
 export class State {

--- a/src/image-zoom/image-zoom.type.ts
+++ b/src/image-zoom/image-zoom.type.ts
@@ -176,10 +176,15 @@ export class Props {
   };
 
   /**
-   * Allows overriding the default onStartShouldSetResponder behavior.
+   * Allows overriding the default onStartShouldSetPanResponder behavior.
    * By default, always becomes the responder
    */
-  public onStartShouldSetResponder = () => true;
+  public onStartShouldSetPanResponder = () => true;
+
+  /**
+   * Allows defining the onMoveShouldSetResponder behavior.
+   */
+  public onMoveShouldSetPanResponder?: () => boolean;
 
   /**
    * Allows overriding the default onPanResponderTerminationRequest behavior.

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,5 @@
 import ImageZoom from './image-zoom/image-zoom.component';
 
 export default ImageZoom;
+export * from './image-zoom/image-zoom.type';
+


### PR DESCRIPTION
This PR allows passing in the various `*ShouldSetResponder` props, to control when the ImageZoom takes control.

Also included:
- Exports the types so the consumer has access in their own code
- Prefix props/state with `ImageZoom*` to avoid conflicts with other libraries props and state

Closes #107 
Closes #94 

(Prettier seems to have collapsed the table formatting in the readme, but I think it's easier to maintain this way anyway)

Until this PR is accepted, I have a fork with these changes, as well as a perf fix for large images: https://github.com/kingdaro/react-native-image-zoom/tree/kingdaro-package