### PR TITLE
Default to (and thus allow) a zero second centerOn duration

### DIFF
--- a/src/image-zoom/image-zoom.component.tsx
+++ b/src/image-zoom/image-zoom.component.tsx
@@ -603,7 +603,7 @@ export default class ImageViewer extends React.Component<ImageZoomProps, ImageZo
     this.positionX = params.x;
     this.positionY = params.y;
     this.scale = params.scale;
-    const duration = params.duration || 300;
+    const duration = params.duration || 0;
     Animated.parallel([
       Animated.timing(this.animatedScale, {
         toValue: this.scale,


### PR DESCRIPTION
Currently, duration = params.duration || 300 excludes the possibility of an instantaneous centerOn, which is sometimes desirable. This now adds instantaneous functionality, and sets this as the default.