### PR TITLE
Add `initialScale` property

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ export default class App extends React.Component {
 | enableCenterFocus | boolean | for disabling focus on image center if user doesn't want it | true |
 | onSwipeDown | () => void | function that fires when user swipes down | null |
 | swipeDownThreshold | number | threshold for firing swipe down function | 230 |
+| initialScale | number | initial zoom | 1 |
 | minScale | number | minimum zoom scale | 0.6 |
 | maxScale | number | maximum zoom scale | 10 |
 | useNativeDriver | boolean | Whether to animate using [`useNativeDriver`](https://reactnative.dev/docs/animations#using-the-native-driver) | false |

--- a/src/image-zoom/image-zoom.component.tsx
+++ b/src/image-zoom/image-zoom.component.tsx
@@ -18,8 +18,9 @@ export default class ImageViewer extends React.Component<ImageZoomProps, ImageZo
   private animatedPositionY = new Animated.Value(0);
 
   // 缩放大小
-  private scale = 1;
-  private animatedScale = new Animated.Value(1);
+  private initialScale = this.props.initialScale;
+  private scale = this.initialScale;
+  private animatedScale = new Animated.Value(this.initialScale);
   private zoomLastDistance: number | null = null;
   private zoomCurrentDistance = 0;
 
@@ -132,20 +133,20 @@ export default class ImageViewer extends React.Component<ImageZoomProps, ImageZo
           this.isDoubleClick = true;
 
           if (this.props.enableDoubleClickZoom) {
-            if (this.scale > 1 || this.scale < 1) {
+            if (this.scale !== this.initialScale) {
               // 回归原位
-              this.scale = 1;
+              this.scale = this.initialScale;
 
               this.positionX = 0;
               this.positionY = 0;
             } else {
               // 开始在位移地点缩放
               // 记录之前缩放比例
-              // 此时 this.scale 一定为 1
+              // 此时 this.scale 一定为 `this.initialScale`
               const beforeScale = this.scale;
 
               // 开始缩放
-              this.scale = 2;
+              this.scale *= 2;
 
               // 缩放 diff
               const diffScale = this.scale - beforeScale;
@@ -461,8 +462,8 @@ export default class ImageViewer extends React.Component<ImageZoomProps, ImageZo
   public resetScale = (): void => {
     this.positionX = 0;
     this.positionY = 0;
-    this.scale = 1;
-    this.animatedScale.setValue(1);
+    this.scale = this.initialScale;
+    this.animatedScale.setValue(this.initialScale);
   };
 
   public panResponderReleaseResolve = (): void => {
@@ -477,9 +478,9 @@ export default class ImageViewer extends React.Component<ImageZoomProps, ImageZo
       }
     }
 
-    if (this.props.enableCenterFocus && this.scale < 1) {
-      // 如果缩放小于1，强制重置为 1
-      this.scale = 1;
+    if (this.props.enableCenterFocus && this.scale < this.initialScale) {
+      // 如果缩放小于`this.initialScale`，强制重置为 `this.initialScale`
+      this.scale = this.initialScale;
       Animated.timing(this.animatedScale, {
         toValue: this.scale,
         duration: 100,
@@ -540,7 +541,7 @@ export default class ImageViewer extends React.Component<ImageZoomProps, ImageZo
     }
 
     // 拖拽正常结束后,如果没有缩放,直接回到0,0点
-    if (this.props.enableCenterFocus && this.scale === 1) {
+    if (this.props.enableCenterFocus && this.scale === this.initialScale) {
       this.positionX = 0;
       this.positionY = 0;
       Animated.timing(this.animatedPositionX, {

--- a/src/image-zoom/image-zoom.type.ts
+++ b/src/image-zoom/image-zoom.type.ts
@@ -107,6 +107,11 @@ export class ImageZoomProps {
   public useHardwareTextureAndroid?: boolean = true;
 
   /**
+   * iniatial zoom scale
+   */
+  public initialScale?: number = 1.0;
+
+  /**
    * minimum zoom scale
    */
   public minScale?: number = 0.6;


### PR DESCRIPTION
## Motivation 

Frequently when user zooms too much the contents are pixelated. One way to fix is to use a much bigger image/SVG/etc and set the initial scale to some small value. This PR allows doing that by adding the option to set `initialScale`.

## Changes

Added `initialScale` prop with types and updated README

## Example code and GIF

```jsx
import React from 'react';
import {SafeAreaView, View, Dimensions, Animated} from 'react-native';
import ImageZoom from 'react-native-image-pan-zoom';
import {Svg, Circle} from 'react-native-svg';

const AnimSvg = Animated.createAnimatedComponent(Svg);
export default () => {
  return (
    <SafeAreaView style={[{flex: 1}, styles.container]}>
      <ImageZoom
        cropWidth={Dimensions.get('window').width}
        cropHeight={Dimensions.get('window').height}
        imageWidth={150}
        imageHeight={150}
        minScale={0.3}
        maxScale={25}
        initialScale={2}
        useNativeDriver={true}>
        <AnimSvg
          viewBox={`0 0 150 ${150}`}
          height="300"
          width="300"
          style={{backgroundColor: 'pink'}}>
          <Circle cx="50" cy="50" r="50" stroke={'black'} />
        </AnimSvg>
      </ImageZoom>
      <View>
        <Svg height="150" width="150" style={{backgroundColor: 'lightblue'}}>
          <Circle cx="50" cy="50" r="50" stroke={'black'} />
        </Svg>
      </View>
    </SafeAreaView>
  );
};
const styles = {
  container: {justifyContent: 'center', alignItems: 'center'},
  rectangle: {
    backgroundColor: 'pink',
    width: 100,
    height: 100,
  },
};
```

![Screen Recording 2020-09-06 at 19 12 39](https://user-images.githubusercontent.com/12465392/92331213-5704e580-f075-11ea-9319-eb19e8fc7c1d.gif)

