### PR TITLE
Slow zoom out with fingers gets stuck on scale less than 1 fix(It wasn't recovering back to scale 1)

### DIFF
--- a/src/image-zoom/image-zoom.component.tsx
+++ b/src/image-zoom/image-zoom.component.tsx
@@ -438,7 +438,7 @@ export default class ImageViewer extends React.Component<ImageZoomProps, ImageZo
       const moveDistance = Math.sqrt(gestureState.dx * gestureState.dx + gestureState.dy * gestureState.dy);
       const { locationX, locationY, pageX, pageY } = evt.nativeEvent;
 
-      if (evt.nativeEvent.changedTouches.length === 1 && moveDistance < (this.props.clickDistance || 0)) {
+      if (this.scale >= 1 && evt.nativeEvent.changedTouches.length === 1 && moveDistance < (this.props.clickDistance || 0)) {
         this.singleClickTimeout = setTimeout(() => {
           if (this.props.onClick) {
             this.props.onClick({ locationX, locationY, pageX, pageY });


### PR DESCRIPTION
`onPanResponderRelease` now always knows how to bounce back to scale 1 when it's zoomed out less than scale 1.

Previously, when you are gently zooming out and stopped your gesture slowly, then it holds the picture's scale to the value even if it's lower than 1. You had to zoom-out with **flicker** your fingers then it will successfully bounce back to scale 1.

After this fix, it will always zoom back to scale 1 after your fingers are released no matter what speed of your fingers was at. 

![zoom-out-stuck](https://user-images.githubusercontent.com/4941095/93516121-947c3500-f8f7-11ea-842a-d05d611550c7.gif) ![zoom-out-works](https://user-images.githubusercontent.com/4941095/93516132-97772580-f8f7-11ea-9d7f-ae0f3c636fd0.gif)
