### PR TITLE
Allow zero for `duration` parameter for centerOn method

### DIFF
--- a/src/image-zoom/image-zoom.component.tsx
+++ b/src/image-zoom/image-zoom.component.tsx
@@ -603,7 +603,7 @@ export default class ImageViewer extends React.Component<ImageZoomProps, ImageZo
     this.positionX = params.x;
     this.positionY = params.y;
     this.scale = params.scale;
-    const duration = params.duration || 300;
+    const duration = params.duration ?? 300;
     Animated.parallel([
       Animated.timing(this.animatedScale, {
         toValue: this.scale,


### PR DESCRIPTION
Hi there! First of all, thanks for maintaining this cool project! 💪

This pull request aims to allow developers to specify `0` as a valid value for the `duration` parameter passed to `centerOn` method. Currently, specifying `0` leads to having `300` as a fallback value due to the fact that zero is treated as a falsy value, thus the expression `0 || 300` returns `300`. In our use case, it is required just to show part of the big image, and animation is unnecessary in the scenario we try to implement. My intuition was to just specify zero for the `duration` parameter, but it didn't work. To achieve the desired outcome I currently need to specify `1` or `0.1` as animation duration, which is, in my opinion, might be a bit confusing for newcomers.

 I think we could utilize [nullish coalescing](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Nullish_coalescing_operator) here. Luckily, there's no additional configuration required as TypeScript 3.9.2 already supports it.

Please, let me know what do you think about this!